### PR TITLE
Restrict MySQL port binding to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - mysql_data:/var/lib/mysql
       - ./scripts/setup/init_database.sql:/docker-entrypoint-initdb.d/init.sql
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       interval: 10s


### PR DESCRIPTION
For ssh tunnel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configuration to enhance security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->