### PR TITLE
Persist dead-end theme page status in the database, expose no_content…

### DIFF
--- a/app/controllers/search_controller.py
+++ b/app/controllers/search_controller.py
@@ -41,7 +41,7 @@ from app.constants import (
 )
 
 logger = logging.getLogger(__name__)
-ThemePageItem = Union[ContentItem, Dict[str, Any]]
+ThemePageItem = Union[ContentItem, SearchResult, Dict[str, Any]]
 
 
 class SearchController:
@@ -53,6 +53,7 @@ class SearchController:
     _SEARCH_ID_SIGNATURE_MARKER = "c0de"
     _SEARCH_ID_SIGNATURE_HEX_LENGTH = 8
     _THEME_PAGE_LOOKUP_CACHE_TTL_SECONDS = 30.0
+    _THEME_PAGE_NO_CONTENT_TAG = "no_content"
 
     @staticmethod
     def _pick_display_title(title: Optional[str], short_title: Optional[str]) -> str:
@@ -66,10 +67,6 @@ class SearchController:
         self._search_cache: Dict[
             Tuple[object, ...],
             Tuple[float, List["SearchResult"]],
-        ] = {}
-        self._theme_page_non_empty_cache: Dict[
-            str,
-            Tuple[float, bool],
         ] = {}
 
     @staticmethod
@@ -87,60 +84,15 @@ class SearchController:
         """Return True when the theme page has its own text content."""
         return bool(item.get("has_text_content")) if isinstance(item, dict) else item.has_text_content
 
-    def _get_non_empty_theme_page_ids(self, theme_page_ids: List[str]) -> set[str]:
-        """
-        Return theme-page IDs that have linked content in theme_page_content.
-
-        Theme pages with text content are handled separately by the caller.
-        On lookup failures, fail open and keep the requested IDs visible.
-        """
-        if not theme_page_ids:
-            return set()
-
-        unique_theme_page_ids = tuple(dict.fromkeys(theme_page_ids))
-        now = time.monotonic()
-
-        stale_keys = [
-            cache_key
-            for cache_key, (cached_at, _) in list(self._theme_page_non_empty_cache.items())
-            if now - cached_at >= self._THEME_PAGE_LOOKUP_CACHE_TTL_SECONDS
-        ]
-        for cache_key in stale_keys:
-            del self._theme_page_non_empty_cache[cache_key]
-
-        cached_non_empty_theme_page_ids = {
-            theme_page_id
-            for theme_page_id in unique_theme_page_ids
-            if (cached := self._theme_page_non_empty_cache.get(theme_page_id))
-            and now - cached[0] < self._THEME_PAGE_LOOKUP_CACHE_TTL_SECONDS
-            and cached[1]
-        }
-        missing_theme_page_ids = [
-            theme_page_id
-            for theme_page_id in unique_theme_page_ids
-            if theme_page_id not in self._theme_page_non_empty_cache
-            or now - self._theme_page_non_empty_cache[theme_page_id][0] >= self._THEME_PAGE_LOOKUP_CACHE_TTL_SECONDS
-        ]
-        if not missing_theme_page_ids:
-            return cached_non_empty_theme_page_ids
-
-        non_empty_theme_page_ids = content_repository.get_non_empty_theme_page_ids(
-            missing_theme_page_ids
-        )
-        if non_empty_theme_page_ids is None:
-            logger.warning(
-                "Failed to determine empty theme pages; keeping %d theme pages visible",
-                len(unique_theme_page_ids),
-            )
-            return set(unique_theme_page_ids)
-
-        fetched_non_empty_theme_page_ids = set(non_empty_theme_page_ids)
-        for theme_page_id in missing_theme_page_ids:
-            self._theme_page_non_empty_cache[theme_page_id] = (
-                now,
-                theme_page_id in fetched_non_empty_theme_page_ids,
-            )
-        return cached_non_empty_theme_page_ids | fetched_non_empty_theme_page_ids
+    @staticmethod
+    def _theme_page_item_is_dead_end(item: ThemePageItem) -> bool:
+        """Return True when the item is a theme page marked as a dead end in storage."""
+        if isinstance(item, dict):
+            return bool(item.get("is_dead_end_theme_page"))
+        if hasattr(item, "is_dead_end_theme_page"):
+            return bool(item.is_dead_end_theme_page)
+        content_item = content_service.get_content_by_id(item.id)
+        return bool(content_item.is_dead_end_theme_page) if content_item else False
 
     def _filter_empty_theme_page_results(
         self,
@@ -155,13 +107,15 @@ class SearchController:
         if not theme_page_ids:
             return results
 
-        non_empty_theme_page_ids = self._get_non_empty_theme_page_ids(theme_page_ids)
+        empty_theme_page_ids = self._get_empty_theme_page_ids([
+            result for result in results
+            if self._is_theme_page_info_type(result.info_type)
+        ])
         return [
             result
             for result in results
             if not self._is_theme_page_info_type(result.info_type)
-            or result.has_text_content
-            or result.id in non_empty_theme_page_ids
+            or result.id not in empty_theme_page_ids
         ]
 
     def _filter_empty_theme_page_items(
@@ -172,23 +126,28 @@ class SearchController:
         if not theme_pages:
             return theme_pages
 
-        theme_page_ids = []
-        for item in theme_pages:
-            item_id = self._get_theme_page_item_id(item)
-            if item_id:
-                theme_page_ids.append(item_id)
+        empty_theme_page_ids = self._get_empty_theme_page_ids(theme_pages)
+        return [
+            item
+            for item in theme_pages
+            if (item_id := self._get_theme_page_item_id(item)) is None
+            or item_id not in empty_theme_page_ids
+        ]
 
-        non_empty_theme_page_ids = self._get_non_empty_theme_page_ids(theme_page_ids)
+    def _get_empty_theme_page_ids(self, theme_page_items: List[ThemePageItem]) -> set[str]:
+        """Return theme-page IDs marked as dead ends in the database/content cache."""
+        return {
+            item_id
+            for item in theme_page_items
+            if (item_id := self._get_theme_page_item_id(item))
+            and self._theme_page_item_is_dead_end(item)
+        }
 
-        filtered = []
-        for item in theme_pages:
-            item_id = self._get_theme_page_item_id(item)
-            has_text_content = self._theme_page_item_has_text_content(item)
-
-            if has_text_content or item_id in non_empty_theme_page_ids:
-                filtered.append(item)
-
-        return filtered
+    def _build_theme_page_tags(self, is_empty_theme_page: bool) -> List[str]:
+        """Return frontend-facing tags for a theme page."""
+        if is_empty_theme_page:
+            return [self._THEME_PAGE_NO_CONTENT_TAG]
+        return []
 
     async def search(
         self,
@@ -572,7 +531,7 @@ class SearchController:
                     document_url=theme_page.public_document_url,
                     is_pdf_only=theme_page.is_pdf_only,
                     score=max_score,
-                    explanation=f"Theme fallback (fuzzy): {int(max_score * 100)}%"
+                    explanation=f"Theme fallback (fuzzy): {int(max_score * 100)}%",
                 ))
 
         # Sort by score descending
@@ -1050,7 +1009,7 @@ class SearchController:
 
         # Get theme pages from repository
         theme_pages = content_repository.get_theme_pages(category=category)
-        theme_pages = self._filter_empty_theme_page_items(theme_pages)
+        empty_theme_page_ids = self._get_empty_theme_page_ids(theme_pages)
 
         # Convert to ThemePageResult objects
         results = []
@@ -1065,6 +1024,7 @@ class SearchController:
                 ),
                 info_type='temaside',
                 path=item.get('path', ''),
+                tags=self._build_theme_page_tags(item.get('id', '') in empty_theme_page_ids),
             ))
 
         return ThemePageResponse(
@@ -1094,13 +1054,15 @@ class SearchController:
         all_content = content_service.get_all_content()
         TYPE_PRIORITY = {"temaside": 0, "retningslinje": 1}
         matches = []  # (match_type 0=prefix/1=substring, type_priority, display_title_len, page)
-        pending_theme_matches: List[Tuple[int, int, int, ContentItem]] = []
 
         searchable_items = [
             item
             for item in all_content
             if item.content_type in content_service.searchable_types
         ]
+        empty_theme_page_ids = self._get_empty_theme_page_ids(
+            [item for item in searchable_items if self._is_theme_page_info_type(item.content_type)]
+        )
 
         for page in searchable_items:
             title_lower = page.title.lower()
@@ -1125,22 +1087,10 @@ class SearchController:
                 matches.append(match_entry)
                 continue
 
-            if page.has_text_content:
-                matches.append(match_entry)
+            if page.id in empty_theme_page_ids:
                 continue
 
-            pending_theme_matches.append(match_entry)
-
-        if pending_theme_matches:
-            filtered_theme_items = self._filter_empty_theme_page_items(
-                [entry[3] for entry in pending_theme_matches]
-            )
-            allowed_theme_ids = {item.id for item in filtered_theme_items}
-            matches.extend(
-                entry
-                for entry in pending_theme_matches
-                if entry[3].id in allowed_theme_ids
-            )
+            matches.append(match_entry)
 
         matches.sort(key=lambda x: (x[0], x[1], x[2]))
         top = [m[3] for m in matches[:max_suggestions]]

--- a/app/controllers/search_controller.py
+++ b/app/controllers/search_controller.py
@@ -562,6 +562,11 @@ class SearchController:
 
         # Fetch all children in ONE database query (much faster!)
         all_children = content_repository.get_theme_pages_content_batch(theme_page_ids)
+        if all_children is None:
+            logger.warning(
+                "Could not load theme page children batch for search results; returning results without populated children"
+            )
+            return results
 
         # Populate each theme page with its children
         for result in results:

--- a/app/dto/response/content.py
+++ b/app/dto/response/content.py
@@ -3,7 +3,7 @@ Content response DTOs.
 """
 
 from datetime import datetime
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 from typing import List, Optional
 
 
@@ -19,6 +19,7 @@ class ContentLinkResponse(BaseModel):
     path: Optional[str] = None
     last_reviewed_date: Optional[datetime] = None
     children: Optional[List["ContentLinkResponse"]] = None  # Populated for barn links (1st level only)
+    tags: List[str] = Field(default_factory=list)
 
     @model_validator(mode='after')
     def validate_id_or_href(self):
@@ -50,6 +51,7 @@ class LinkedContentItem(BaseModel):
     has_text_content: bool = False
     document_url: Optional[str] = None
     is_pdf_only: bool = False
+    tags: List[str] = Field(default_factory=list)
 
 
 class GroupedLinkedContent(BaseModel):

--- a/app/dto/response/search.py
+++ b/app/dto/response/search.py
@@ -47,6 +47,7 @@ class SearchResult(BaseModel):
     root_publication: Optional[ContentSummaryResponse] = None
     children: Optional[List[GroupedContent]] = None  # For theme pages with linked content
     pipeline: Optional[PipelineScores] = None
+    tags: List[str] = Field(default_factory=list)
 
 
 class SearchResponse(BaseModel):
@@ -120,6 +121,7 @@ class ThemePageResult(BaseModel):
     display_title: str
     info_type: str
     path: str
+    tags: List[str] = Field(default_factory=list)
 
 
 class ThemePageResponse(BaseModel):
@@ -136,6 +138,7 @@ class Suggestion(BaseModel):
     display_title: str
     info_type: Optional[str] = None
     path: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
 
 
 class SuggestionResponse(BaseModel):

--- a/app/dto/response/search.py
+++ b/app/dto/response/search.py
@@ -47,7 +47,6 @@ class SearchResult(BaseModel):
     root_publication: Optional[ContentSummaryResponse] = None
     children: Optional[List[GroupedContent]] = None  # For theme pages with linked content
     pipeline: Optional[PipelineScores] = None
-    tags: List[str] = Field(default_factory=list)
 
 
 class SearchResponse(BaseModel):
@@ -138,7 +137,6 @@ class Suggestion(BaseModel):
     display_title: str
     info_type: Optional[str] = None
     path: Optional[str] = None
-    tags: List[str] = Field(default_factory=list)
 
 
 class SuggestionResponse(BaseModel):

--- a/app/entities/content.py
+++ b/app/entities/content.py
@@ -83,6 +83,7 @@ class ContentItem(BaseModel):
     links: List[ContentLink] = []
     has_text_content: bool = False
     document_url: Optional[str] = None
+    is_dead_end_theme_page: bool = False
     url: Optional[str] = None
 
     # Info type-specific fields (extensible pattern for future types)

--- a/app/routes/content.py
+++ b/app/routes/content.py
@@ -58,6 +58,15 @@ def _pick_display_title(title: Optional[str], short_title: Optional[str]) -> str
     return title or ""
 
 
+def _theme_page_tags_for_content_item(content: Optional[ContentItem]) -> List[str]:
+    """Return no_content tag for theme-page items that are navigation dead ends."""
+    if not content or normalize_content_type(content.content_type) != "temaside":
+        return []
+    if content.is_dead_end_theme_page:
+        return ["no_content"]
+    return []
+
+
 class NormalizedRelations(TypedDict):
     parent: Optional[ContentSummaryResponse]
     root_publication: Optional[ContentSummaryResponse]
@@ -114,10 +123,17 @@ def _children_from_content_links(links: List) -> List[ContentLinkResponse]:
         if gl.rel != "barn":
             continue
         last_reviewed_date = None
+        tags: List[str] = []
         if gl.id:
             child = content_service.get_content_by_id(gl.id)
             if child:
                 last_reviewed_date = child.sist_faglig_oppdatert
+                tags = _theme_page_tags_for_content_item(child)
+        elif gl.href:
+            child = content_service.get_content_by_path(_public_path_from_href(gl.href) or "")
+            if child:
+                last_reviewed_date = child.sist_faglig_oppdatert
+                tags = _theme_page_tags_for_content_item(child)
         result.append(ContentLinkResponse(
             rel=gl.rel,
             type=gl.type,
@@ -125,6 +141,7 @@ def _children_from_content_links(links: List) -> List[ContentLinkResponse]:
             id=gl.id,
             href=gl.href,
             last_reviewed_date=last_reviewed_date,
+            tags=tags,
         ))
     return result
 
@@ -143,6 +160,7 @@ async def _build_links_with_children(links: List[ContentLink]) -> List[ContentLi
     async def _build_link(link: ContentLink) -> ContentLinkResponse:
         children: List[ContentLinkResponse] = []
         last_reviewed_date = None
+        tags: List[str] = []
 
         # Look up cached content for id-based links
         cached = None
@@ -155,6 +173,7 @@ async def _build_links_with_children(links: List[ContentLink]) -> List[ContentLi
 
         if cached:
             last_reviewed_date = cached.sist_faglig_oppdatert
+            tags = _theme_page_tags_for_content_item(cached)
 
         if link.rel == "barn":
             if cached:
@@ -170,6 +189,7 @@ async def _build_links_with_children(links: List[ContentLink]) -> List[ContentLi
                         child = content_service.get_content_by_path(public_path)
                         if child:
                             last_reviewed_date = child.sist_faglig_oppdatert
+                            tags = _theme_page_tags_for_content_item(child)
                             children = _children_from_content_links(child.links)
                     elif _is_api_href(link.href):
                         # Fallback: fetch from Helsedir API only for API URLs
@@ -182,6 +202,13 @@ async def _build_links_with_children(links: List[ContentLink]) -> List[ContentLi
                                     title=al.get("tittel"),
                                     id=al.get("id"),
                                     href=al.get("href"),
+                                    tags=_theme_page_tags_for_content_item(
+                                        content_service.get_content_by_id(al.get("id"))
+                                        if al.get("id")
+                                        else content_service.get_content_by_path(
+                                            _public_path_from_href(al.get("href") or "") or ""
+                                        )
+                                    ),
                                 )
                                 for al in (data.get("links") or [])
                                 if al.get("rel") == "barn"
@@ -204,6 +231,7 @@ async def _build_links_with_children(links: List[ContentLink]) -> List[ContentLi
             path=link.path,
             last_reviewed_date=last_reviewed_date,
             children=children,
+            tags=tags,
         )
 
     return list(await asyncio.gather(*[_build_link(link) for link in links]))
@@ -378,6 +406,9 @@ def _get_theme_page_linked_content(theme_page_id: str) -> Optional[List[GroupedL
             has_text_content=metadata["has_text_content"],
             document_url=metadata["document_url"],
             is_pdf_only=metadata["is_pdf_only"],
+            tags=_theme_page_tags_for_content_item(
+                content_service.get_content_by_id(content_item.get('id', ''))
+            ),
         )
         grouped[info_type].append(linked_item)
 

--- a/app/services/data/content_service.py
+++ b/app/services/data/content_service.py
@@ -115,6 +115,115 @@ class ContentService:
             attachments=attachments,
         )
 
+    @staticmethod
+    def _normalize_internal_path(value: Optional[str]) -> Optional[str]:
+        """Normalize an internal path or href for content lookups."""
+        if not value or not isinstance(value, str):
+            return None
+        normalized = value.strip()
+        if not normalized:
+            return None
+        if normalized.startswith("http://") or normalized.startswith("https://"):
+            return None
+        if not normalized.startswith("/"):
+            normalized = f"/{normalized.lstrip('/')}"
+        return normalized
+
+    def _compute_dead_end_theme_page_flags(self) -> Dict[str, bool]:
+        """Compute which theme pages are true dead ends and should get no_content."""
+        theme_pages = [
+            item for item in self.content
+            if normalize_content_type(item.content_type) == "temaside"
+        ]
+        if not theme_pages:
+            return {}
+
+        theme_page_ids = [item.id for item in theme_pages]
+        linked_children = content_repository.get_theme_pages_content_batch(theme_page_ids)
+
+        direct_theme_children: Dict[str, Set[str]] = {theme_id: set() for theme_id in theme_page_ids}
+        direct_non_theme_child: Dict[str, bool] = {theme_id: False for theme_id in theme_page_ids}
+
+        for theme_page in theme_pages:
+            children = linked_children.get(theme_page.id, [])
+            for child in children:
+                child_type = normalize_content_type(child.get("info_type"))
+                child_id = child.get("id")
+                if child_type == "temaside" and child_id:
+                    direct_theme_children[theme_page.id].add(str(child_id))
+                else:
+                    direct_non_theme_child[theme_page.id] = True
+
+            for link in theme_page.links:
+                if link.rel != "barn":
+                    continue
+
+                resolved_child = None
+                if link.id:
+                    resolved_child = self.get_content_by_id(link.id)
+                if resolved_child is None:
+                    child_path = self._normalize_internal_path(link.path) or self._normalize_internal_path(link.href)
+                    if child_path:
+                        resolved_child = self.get_content_by_path(child_path)
+
+                if resolved_child is not None:
+                    child_type = normalize_content_type(resolved_child.content_type)
+                    if child_type == "temaside":
+                        direct_theme_children[theme_page.id].add(resolved_child.id)
+                    else:
+                        direct_non_theme_child[theme_page.id] = True
+                    continue
+
+                if normalize_content_type(link.type) != "temaside":
+                    direct_non_theme_child[theme_page.id] = True
+
+        theme_pages_by_id = {item.id: item for item in theme_pages}
+        navigable_cache: Dict[str, bool] = {}
+        in_progress: Set[str] = set()
+
+        def is_navigable(theme_page_id: str) -> bool:
+            if theme_page_id in navigable_cache:
+                return navigable_cache[theme_page_id]
+
+            theme_page = theme_pages_by_id.get(theme_page_id)
+            if not theme_page:
+                return False
+            if theme_page.has_text_content or direct_non_theme_child.get(theme_page_id, False):
+                navigable_cache[theme_page_id] = True
+                return True
+            if theme_page_id in in_progress:
+                logger.warning("Detected cycle while computing dead-end theme page flags for %s", theme_page_id)
+                return False
+
+            in_progress.add(theme_page_id)
+            navigable = any(
+                is_navigable(child_id)
+                for child_id in direct_theme_children.get(theme_page_id, set())
+            )
+            in_progress.remove(theme_page_id)
+            navigable_cache[theme_page_id] = navigable
+            return navigable
+
+        return {
+            theme_page.id: not is_navigable(theme_page.id)
+            for theme_page in theme_pages
+        }
+
+    def refresh_dead_end_theme_page_flags(self, persist: bool = True) -> Dict[str, bool]:
+        """Recompute dead-end theme page flags for current in-memory content."""
+        dead_end_flags = self._compute_dead_end_theme_page_flags()
+        for theme_page_id, is_dead_end in dead_end_flags.items():
+            content_item = self.content_by_id.get(theme_page_id)
+            if content_item:
+                content_item.is_dead_end_theme_page = is_dead_end
+
+        if persist and dead_end_flags:
+            updated_count = content_repository.update_dead_end_theme_page_flags(dead_end_flags)
+            if updated_count:
+                logger.info("Updated dead-end theme page flags for %d theme pages", updated_count)
+
+        return dead_end_flags
+
     def load_content(self):
         """Load content from database cache."""
         # Load searchable info types from DB; fall back to hardcoded constants
@@ -122,6 +231,7 @@ class ContentService:
         db_searchable = content_repository.get_searchable_info_types()
         self.searchable_types = db_searchable if db_searchable else ALLOWED_INFO_TYPES_SET
         logger.debug("Searchable info types (%d): %s", len(self.searchable_types), sorted(self.searchable_types))
+        content_repository.ensure_dead_end_theme_page_column()
 
         db_content = database_service.get_all_content()
 
@@ -185,6 +295,7 @@ class ContentService:
                     else document_meta["has_text_content"]
                 ),
                 document_url=item.get("document_url") or document_meta["document_url"],
+                is_dead_end_theme_page=bool(item.get("is_dead_end_theme_page")),
                 anbefaling_fields=anbefaling_fields,
                 ehelsestandard_fields=ehelsestandard_fields,
             )
@@ -268,6 +379,7 @@ class ContentService:
 
             # Reload from DB so local-only fields like nki_indicator_id survive refreshes.
             self.load_content()
+            self.refresh_dead_end_theme_page_flags(persist=True)
             print(f"Reloaded {len(self.content)} content items from database cache after API refresh")
 
         except HelseDirectorateAPIError as e:

--- a/app/services/data/content_service.py
+++ b/app/services/data/content_service.py
@@ -6,7 +6,9 @@ Loads content from database cache or Helsedirektoratet API.
 
 import json
 import logging
+import re
 from typing import Any, Dict, List, Optional, Set
+from urllib.parse import urlparse
 from pydantic import ValidationError
 from app.entities.content import (
     ContentItem,
@@ -19,8 +21,10 @@ from app.services.data.database_service import database_service
 from app.services.data.document_metadata import compute_document_metadata
 from app.services.repositories.content_repository import content_repository
 from app.constants import ALLOWED_INFO_TYPES_SET, normalize_content_type
+from app.config import settings
 
 logger = logging.getLogger(__name__)
+_HELSEDIR_ID_RE = re.compile(r'/innhold/[^/]+/([0-9]{4}-[0-9]{4}[-a-f0-9]+)', re.IGNORECASE)
 
 
 class ContentService:
@@ -129,6 +133,52 @@ class ContentService:
             normalized = f"/{normalized.lstrip('/')}"
         return normalized
 
+    @staticmethod
+    def _content_id_from_href(value: Optional[str]) -> Optional[str]:
+        """Extract a Helsedir content ID from an API href when present."""
+        if not value or not isinstance(value, str):
+            return None
+        match = _HELSEDIR_ID_RE.search(value.strip())
+        return match.group(1) if match else None
+
+    @staticmethod
+    def _public_path_from_href(value: Optional[str]) -> Optional[str]:
+        """Resolve a public Helsedir path from a relative path or public URL."""
+        normalized = ContentService._normalize_internal_path(value)
+        if normalized:
+            return normalized
+        if not value or not isinstance(value, str):
+            return None
+
+        parsed = urlparse(value.strip())
+        if not parsed.scheme or not parsed.netloc:
+            return None
+
+        public_base = urlparse(settings.helsedir_public_base_url)
+        if parsed.netloc != public_base.netloc:
+            return None
+
+        return (parsed.path or "").rstrip("/") or "/"
+
+    def _resolve_content_link_target(self, link: ContentLink) -> Optional[ContentItem]:
+        """Resolve a content link to a cached content item via id, public path, or API href."""
+        if link.id:
+            resolved_child = self.get_content_by_id(link.id)
+            if resolved_child is not None:
+                return resolved_child
+
+        child_path = self._normalize_internal_path(link.path) or self._public_path_from_href(link.href)
+        if child_path:
+            resolved_child = self.get_content_by_path(child_path)
+            if resolved_child is not None:
+                return resolved_child
+
+        href_id = self._content_id_from_href(link.href)
+        if href_id:
+            return self.get_content_by_id(href_id)
+
+        return None
+
     def _compute_dead_end_theme_page_flags(self) -> Dict[str, bool]:
         """Compute which theme pages are true dead ends and should get no_content."""
         theme_pages = [
@@ -140,6 +190,12 @@ class ContentService:
 
         theme_page_ids = [item.id for item in theme_pages]
         linked_children = content_repository.get_theme_pages_content_batch(theme_page_ids)
+        linked_children_available = linked_children is not None
+        if linked_children is None:
+            logger.warning(
+                "Could not load theme_page_content batch while computing dead-end theme page flags; falling back to inline links only"
+            )
+            linked_children = {}
 
         direct_theme_children: Dict[str, Set[str]] = {theme_id: set() for theme_id in theme_page_ids}
         direct_non_theme_child: Dict[str, bool] = {theme_id: False for theme_id in theme_page_ids}
@@ -158,13 +214,7 @@ class ContentService:
                 if link.rel != "barn":
                     continue
 
-                resolved_child = None
-                if link.id:
-                    resolved_child = self.get_content_by_id(link.id)
-                if resolved_child is None:
-                    child_path = self._normalize_internal_path(link.path) or self._normalize_internal_path(link.href)
-                    if child_path:
-                        resolved_child = self.get_content_by_path(child_path)
+                resolved_child = self._resolve_content_link_target(link)
 
                 if resolved_child is not None:
                     child_type = normalize_content_type(resolved_child.content_type)
@@ -189,6 +239,9 @@ class ContentService:
             if not theme_page:
                 return False
             if theme_page.has_text_content or direct_non_theme_child.get(theme_page_id, False):
+                navigable_cache[theme_page_id] = True
+                return True
+            if not linked_children_available and not direct_theme_children.get(theme_page_id):
                 navigable_cache[theme_page_id] = True
                 return True
             if theme_page_id in in_progress:
@@ -231,7 +284,10 @@ class ContentService:
         db_searchable = content_repository.get_searchable_info_types()
         self.searchable_types = db_searchable if db_searchable else ALLOWED_INFO_TYPES_SET
         logger.debug("Searchable info types (%d): %s", len(self.searchable_types), sorted(self.searchable_types))
-        content_repository.ensure_dead_end_theme_page_column()
+        if not content_repository.has_dead_end_theme_page_column():
+            logger.warning(
+                "content.is_dead_end_theme_page is missing; dead-end theme page persistence may be unavailable until migration/backfill is run"
+            )
 
         db_content = database_service.get_all_content()
 

--- a/app/services/repositories/content_repository.py
+++ b/app/services/repositories/content_repository.py
@@ -75,6 +75,11 @@ class ContentRepository:
             logger.info("Added content.is_dead_end_theme_page column")
             return True
         except mysql.connector.Error as e:
+            if getattr(e, "errno", None) == 1060:
+                logger.info(
+                    "content.is_dead_end_theme_page column already exists; treating concurrent ALTER TABLE as success"
+                )
+                return True
             conn.rollback()
             logger.error("Failed to ensure content.is_dead_end_theme_page column: %s", e)
             return False
@@ -88,6 +93,11 @@ class ContentRepository:
         if not flags_by_theme_page_id:
             return 0
         if not self.has_dead_end_theme_page_column():
+            if not self._warned_missing_dead_end_theme_page:
+                logger.warning(
+                    "Skipping dead-end theme page flag update because content.is_dead_end_theme_page is missing"
+                )
+                self._warned_missing_dead_end_theme_page = True
             return 0
 
         conn = db_pool.get_connection()
@@ -753,7 +763,7 @@ class ContentRepository:
             cursor.close()
             conn.close()
 
-    def get_theme_pages_content_batch(self, theme_page_ids: List[str]) -> Dict[str, List[Dict[str, Any]]]:
+    def get_theme_pages_content_batch(self, theme_page_ids: List[str]) -> Optional[Dict[str, List[Dict[str, Any]]]]:
         """
         Get all content linked to multiple theme pages in a single query (batch operation).
 
@@ -761,14 +771,15 @@ class ContentRepository:
             theme_page_ids: List of theme page IDs
 
         Returns:
-            Dict mapping theme_page_id -> list of linked content items
+            Dict mapping theme_page_id -> list of linked content items.
+            Returns None when the lookup could not be completed.
         """
         if not theme_page_ids:
             return {}
 
         conn = db_pool.get_connection()
         if not conn:
-            return {}
+            return None
 
         cursor = None
         try:
@@ -797,7 +808,7 @@ class ContentRepository:
 
         except mysql.connector.Error as e:
             print(f"Error getting theme pages content batch: {e}")
-            return {}
+            return None
         finally:
             if cursor:
                 cursor.close()

--- a/app/services/repositories/content_repository.py
+++ b/app/services/repositories/content_repository.py
@@ -21,6 +21,7 @@ class ContentRepository:
         self._warned_missing_attachments_json = False
         self._warned_missing_kort_tittel = False
         self._warned_missing_nki_indicator_id = False
+        self._warned_missing_dead_end_theme_page = False
 
     def _serialize_json_field(self, value) -> Optional[str]:
         """Serialize a field to JSON string if needed."""
@@ -34,6 +35,89 @@ class ContentRepository:
     def _is_unknown_column_error(error: mysql.connector.Error, column_name: str) -> bool:
         """Return True when MySQL reports a missing column for the given name."""
         return getattr(error, "errno", None) == 1054 and column_name in str(error)
+
+    def has_dead_end_theme_page_column(self) -> bool:
+        """Return True when content.is_dead_end_theme_page exists."""
+        conn = db_pool.get_connection()
+        if not conn:
+            return False
+
+        cursor = None
+        try:
+            cursor = conn.cursor()
+            cursor.execute("SHOW COLUMNS FROM content LIKE 'is_dead_end_theme_page'")
+            return cursor.fetchone() is not None
+        finally:
+            if cursor:
+                cursor.close()
+            conn.close()
+
+    def ensure_dead_end_theme_page_column(self) -> bool:
+        """Add the dead-end temaside column if it does not exist."""
+        if self.has_dead_end_theme_page_column():
+            return True
+
+        conn = db_pool.get_connection()
+        if not conn:
+            return False
+
+        cursor = None
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                ALTER TABLE content
+                ADD COLUMN is_dead_end_theme_page TINYINT(1) NOT NULL DEFAULT 0
+                AFTER document_url
+                """
+            )
+            conn.commit()
+            logger.info("Added content.is_dead_end_theme_page column")
+            return True
+        except mysql.connector.Error as e:
+            conn.rollback()
+            logger.error("Failed to ensure content.is_dead_end_theme_page column: %s", e)
+            return False
+        finally:
+            if cursor:
+                cursor.close()
+            conn.close()
+
+    def update_dead_end_theme_page_flags(self, flags_by_theme_page_id: Dict[str, bool]) -> int:
+        """Persist dead-end flags for theme pages."""
+        if not flags_by_theme_page_id:
+            return 0
+        if not self.has_dead_end_theme_page_column():
+            return 0
+
+        conn = db_pool.get_connection()
+        if not conn:
+            return 0
+
+        cursor = None
+        try:
+            cursor = conn.cursor()
+            cursor.executemany(
+                """
+                UPDATE content
+                SET is_dead_end_theme_page = %s
+                WHERE id = %s AND info_type = 'temaside'
+                """,
+                [
+                    (1 if is_dead_end else 0, theme_page_id)
+                    for theme_page_id, is_dead_end in flags_by_theme_page_id.items()
+                ],
+            )
+            conn.commit()
+            return cursor.rowcount
+        except mysql.connector.Error as e:
+            conn.rollback()
+            logger.error("Failed to update dead-end theme page flags: %s", e)
+            return 0
+        finally:
+            if cursor:
+                cursor.close()
+            conn.close()
 
     def _execute_content_upsert(
         self,

--- a/scripts/data/migration/backfill_dead_end_theme_pages.py
+++ b/scripts/data/migration/backfill_dead_end_theme_pages.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+Backfill content.is_dead_end_theme_page for cached theme pages.
+
+This script ensures the database column exists, reloads cached content,
+recomputes navigable/dead-end theme pages, and persists the result.
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from app.services.repositories.content_repository import content_repository
+from app.services.data.content_service import content_service
+
+
+def main() -> int:
+    print("Ensuring content.is_dead_end_theme_page exists...")
+    if not content_repository.ensure_dead_end_theme_page_column():
+        print("ERROR: Could not ensure content.is_dead_end_theme_page column")
+        return 1
+
+    print("Reloading cached content...")
+    content_service.reload_content()
+    print("Recalculating and persisting dead-end theme pages...")
+    content_service.refresh_dead_end_theme_page_flags(persist=True)
+
+    theme_pages = [
+        item for item in content_service.get_all_content()
+        if item.content_type.lower() == "temaside"
+    ]
+    dead_end_count = sum(1 for item in theme_pages if item.is_dead_end_theme_page)
+
+    print(f"Theme pages: {len(theme_pages)}")
+    print(f"Dead-end theme pages: {dead_end_count}")
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ Strategy:
 - client provides a session-scoped TestClient over the real FastAPI app.
 """
 
+import copy
 import pytest
 from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
@@ -83,12 +84,12 @@ def mock_content():
     orig_by_path = dict(content_service.content_by_path)
     orig_types = set(content_service.searchable_types)
 
-    content_service.content = list(SAMPLE_CONTENT)
-    content_service.content_by_id = {item.id: item for item in SAMPLE_CONTENT}
+    content_service.content = copy.deepcopy(SAMPLE_CONTENT)
+    content_service.content_by_id = {item.id: item for item in content_service.content}
     content_service.content_by_path = {
-        item.path: item for item in SAMPLE_CONTENT if item.path
+        item.path: item for item in content_service.content if item.path
     }
-    content_service.searchable_types = {item.content_type for item in SAMPLE_CONTENT}
+    content_service.searchable_types = {item.content_type for item in content_service.content}
 
     yield content_service
 

--- a/tests/unit/controllers/test_search_controller.py
+++ b/tests/unit/controllers/test_search_controller.py
@@ -162,7 +162,7 @@ class TestSearchControllerHelpers:
         merged = ctrl._merge_theme_fallback_results(regular, fallback, max_results=4)
         assert len(merged) <= 4
 
-    def test_filter_empty_theme_page_results_removes_empty_theme_pages(self, mocker):
+    def test_filter_empty_theme_page_results_removes_dead_end_theme_pages(self):
         ctrl = SearchController()
         empty_theme = _make_result("empty-theme", 0.8, "temaside")
         empty_theme.has_text_content = False
@@ -173,50 +173,27 @@ class TestSearchControllerHelpers:
             filled_theme,
             _make_result("guide", 0.6, "veileder"),
         ]
-        mocker.patch.object(
-            ctrl,
-            "_get_non_empty_theme_page_ids",
-            return_value={"filled-theme"},
-        )
-
-        filtered = ctrl._filter_empty_theme_page_results(results)
+        with patch(
+            "app.controllers.search_controller.content_service.get_content_by_id",
+            side_effect=lambda content_id: MagicMock(
+                is_dead_end_theme_page=(content_id == "empty-theme")
+            ),
+        ):
+            filtered = ctrl._filter_empty_theme_page_results(results)
 
         assert [result.id for result in filtered] == ["filled-theme", "guide"]
 
-    def test_filter_empty_theme_page_results_keeps_theme_pages_with_text_content(self, mocker):
+    def test_filter_empty_theme_page_results_keeps_theme_pages_with_text_content(self):
         ctrl = SearchController()
         text_theme = _make_result("text-theme", 0.8, "temaside")
         text_theme.has_text_content = True
-        mocker.patch.object(ctrl, "_get_non_empty_theme_page_ids", return_value=set())
-
-        filtered = ctrl._filter_empty_theme_page_results([text_theme])
+        with patch(
+            "app.controllers.search_controller.content_service.get_content_by_id",
+            return_value=MagicMock(is_dead_end_theme_page=False),
+        ):
+            filtered = ctrl._filter_empty_theme_page_results([text_theme])
 
         assert [result.id for result in filtered] == ["text-theme"]
-
-    def test_get_non_empty_theme_page_ids_fails_open_on_lookup_failure(self, mocker):
-        ctrl = SearchController()
-        mocker.patch(
-            "app.controllers.search_controller.content_repository.get_non_empty_theme_page_ids",
-            return_value=None,
-        )
-
-        result = ctrl._get_non_empty_theme_page_ids(["t1", "t2"])
-
-        assert result == {"t1", "t2"}
-
-    def test_get_non_empty_theme_page_ids_reuses_individual_cache_across_input_order(self, mocker):
-        ctrl = SearchController()
-        lookup_mock = mocker.patch(
-            "app.controllers.search_controller.content_repository.get_non_empty_theme_page_ids",
-            return_value={"t1"},
-        )
-
-        first = ctrl._get_non_empty_theme_page_ids(["t1", "t2"])
-        second = ctrl._get_non_empty_theme_page_ids(["t2", "t1"])
-
-        assert first == {"t1"}
-        assert second == {"t1"}
-        lookup_mock.assert_called_once_with(["t1", "t2"])
 
 
 @pytest.mark.unit
@@ -525,16 +502,14 @@ class TestSearchControllerSearchAsync:
 
     def test_get_suggestions_prefix_match(self, mock_content):
         ctrl = SearchController()
-        with patch.object(ctrl, "_get_non_empty_theme_page_ids", return_value={"004"}):
-            response = ctrl.get_suggestions("psykisk")
+        response = ctrl.get_suggestions("psykisk")
         ids = [s.id for s in response.suggestions]
         assert "004" in ids  # "Psykisk helse temaside"
 
     def test_get_suggestions_case_insensitive(self, mock_content):
         ctrl = SearchController()
-        with patch.object(ctrl, "_get_non_empty_theme_page_ids", return_value={"004"}):
-            response_lower = ctrl.get_suggestions("psykisk")
-            response_upper = ctrl.get_suggestions("PSYKISK")
+        response_lower = ctrl.get_suggestions("psykisk")
+        response_upper = ctrl.get_suggestions("PSYKISK")
         assert {s.id for s in response_lower.suggestions} == {
             s.id for s in response_upper.suggestions
         }
@@ -567,63 +542,69 @@ class TestSearchControllerSearchAsync:
         assert len(response.suggestions) <= 5
 
     def test_get_suggestions_excludes_empty_theme_pages(self, mock_content, mocker):
+        from app.services.data.content_service import content_service
+
+        content_service.content_by_id["004"].is_dead_end_theme_page = True
         ctrl = SearchController()
-        mocker.patch.object(
-            ctrl,
-            "_get_non_empty_theme_page_ids",
-            return_value=set(),
-        )
 
         response = ctrl.get_suggestions("psykisk")
 
         assert response.suggestions == []
 
-    def test_get_suggestions_only_checks_matching_theme_pages_for_emptiness(self, mock_content, mocker):
-        from app.services.data.content_service import content_service
-        from app.entities.content import ContentItem
-
-        content_service.content.append(
-            ContentItem(
-                id="005",
-                title="Annen temaside",
-                body="",
-                content_type="temaside",
-                path="/temasider/annen",
-            )
-        )
-        content_service.content_by_id["005"] = content_service.content[-1]
-        content_service.content_by_path["/temasider/annen"] = content_service.content[-1]
-
-        ctrl = SearchController()
-        emptiness_mock = mocker.patch.object(
-            ctrl,
-            "_filter_empty_theme_page_items",
-            side_effect=lambda items: items,
-        )
-
-        ctrl.get_suggestions("psykisk")
-
-        checked_ids = [item.id for item in emptiness_mock.call_args.args[0]]
-        assert checked_ids == ["004"]
-
-    async def test_get_theme_pages_excludes_empty_theme_pages(self, mocker):
+    async def test_get_theme_pages_includes_dead_end_theme_pages(self, mocker):
         ctrl = SearchController()
         mocker.patch(
             "app.controllers.search_controller.content_repository.get_theme_pages",
             return_value=[
-                {"id": "empty", "tittel": "Tom temaside", "path": "/tema/tom", "has_text_content": 0},
-                {"id": "filled", "tittel": "Fylt temaside", "path": "/tema/fylt", "has_text_content": 0},
+                {
+                    "id": "empty",
+                    "tittel": "Tom temaside",
+                    "path": "/tema/tom",
+                    "has_text_content": 0,
+                    "is_dead_end_theme_page": 1,
+                },
+                {
+                    "id": "filled",
+                    "tittel": "Fylt temaside",
+                    "path": "/tema/fylt",
+                    "has_text_content": 0,
+                    "is_dead_end_theme_page": 0,
+                },
             ],
-        )
-        mocker.patch.object(
-            ctrl,
-            "_get_non_empty_theme_page_ids",
-            return_value={"filled"},
         )
 
         response = await ctrl.get_theme_pages()
 
-        assert [result.id for result in response.results] == ["filled"]
+        assert [result.id for result in response.results] == ["empty", "filled"]
+
+    async def test_get_theme_pages_sets_no_content_tag_for_dead_end_theme_pages(self, mocker):
+        ctrl = SearchController()
+        mocker.patch(
+            "app.controllers.search_controller.content_repository.get_theme_pages",
+            return_value=[
+                {
+                    "id": "empty",
+                    "tittel": "Tom temaside",
+                    "path": "/tema/tom",
+                    "has_text_content": 0,
+                    "is_dead_end_theme_page": 1,
+                },
+                {
+                    "id": "filled",
+                    "tittel": "Fylt temaside",
+                    "path": "/tema/fylt",
+                    "has_text_content": 0,
+                    "is_dead_end_theme_page": 0,
+                },
+            ],
+        )
+
+        response = await ctrl.get_theme_pages()
+
+        assert next(result for result in response.results if result.id == "empty").tags == [
+            "no_content"
+        ]
+        assert next(result for result in response.results if result.id == "filled").tags == []
 
 
 @pytest.mark.unit

--- a/tests/unit/routes/test_content_route_helpers.py
+++ b/tests/unit/routes/test_content_route_helpers.py
@@ -95,6 +95,39 @@ class TestBuildLinksWithChildren:
         assert results[0].children == []
         api_mock.assert_not_called()
 
+    async def test_public_theme_href_includes_no_content_tag_for_dead_end_child(self, mock_content, mocker):
+        from app.services.data.content_service import content_service
+
+        dead_end_child = ContentItem(
+            id="child-theme-002",
+            title="Dead-end child",
+            body="",
+            content_type="temaside",
+            path="/digitalisering-og-e-helse/dead-end-child",
+            is_dead_end_theme_page=True,
+        )
+
+        content_service.content.append(dead_end_child)
+        content_service.content_by_id[dead_end_child.id] = dead_end_child
+        content_service.content_by_path[dead_end_child.path] = dead_end_child
+
+        api_mock = mocker.patch(
+            "app.routes.content.helsedir_api_service.get_content_by_href_async"
+        )
+
+        results = await _build_links_with_children([
+            ContentLink(
+                rel="barn",
+                type="temaside",
+                href=dead_end_child.path,
+                tittel=dead_end_child.title,
+            )
+        ])
+
+        assert len(results) == 1
+        assert results[0].tags == ["no_content"]
+        api_mock.assert_not_called()
+
 
 @pytest.mark.unit
 class TestEhelsestandardHelpers:

--- a/tests/unit/services/data/test_content_service.py
+++ b/tests/unit/services/data/test_content_service.py
@@ -161,3 +161,105 @@ def test_refresh_dead_end_theme_page_flags_marks_only_true_dead_ends(mocker):
         content_service.content_by_id = orig_by_id
         content_service.content_by_path = orig_by_path
         content_service.searchable_types = orig_types
+
+
+def test_refresh_dead_end_theme_page_flags_resolves_public_href_children(mocker):
+    from app.services.data.content_service import content_service
+
+    parent = ContentItem(
+        id="theme-parent",
+        title="Parent theme",
+        body="",
+        content_type="temaside",
+        path="/tema/parent",
+        links=[
+            ContentLink(
+                rel="barn",
+                type="temaside",
+                href="https://www.helsedirektoratet.no/tema/child",
+                tittel="Child theme",
+            )
+        ],
+    )
+    child = ContentItem(
+        id="theme-child",
+        title="Child theme",
+        body="Child body",
+        content_type="temaside",
+        path="/tema/child",
+        has_text_content=True,
+    )
+
+    orig_content = content_service.content[:]
+    orig_by_id = dict(content_service.content_by_id)
+    orig_by_path = dict(content_service.content_by_path)
+    orig_types = set(content_service.searchable_types)
+    try:
+        content_service.content = [parent, child]
+        content_service._rebuild_lookup_dicts()
+        content_service.searchable_types = {item.content_type for item in content_service.content}
+
+        mocker.patch(
+            "app.services.data.content_service.content_repository.get_theme_pages_content_batch",
+            return_value={},
+        )
+        update_mock = mocker.patch(
+            "app.services.data.content_service.content_repository.update_dead_end_theme_page_flags",
+            return_value=2,
+        )
+
+        flags = content_service.refresh_dead_end_theme_page_flags(persist=True)
+
+        update_mock.assert_called_once_with(
+            {
+                "theme-parent": False,
+                "theme-child": False,
+            }
+        )
+        assert flags["theme-parent"] is False
+    finally:
+        content_service.content = orig_content
+        content_service.content_by_id = orig_by_id
+        content_service.content_by_path = orig_by_path
+        content_service.searchable_types = orig_types
+
+
+def test_refresh_dead_end_theme_page_flags_fails_open_when_batch_lookup_unavailable(mocker):
+    from app.services.data.content_service import content_service
+
+    unknown_theme = ContentItem(
+        id="theme-unknown",
+        title="Unknown theme",
+        body="",
+        content_type="temaside",
+        path="/tema/unknown",
+    )
+
+    orig_content = content_service.content[:]
+    orig_by_id = dict(content_service.content_by_id)
+    orig_by_path = dict(content_service.content_by_path)
+    orig_types = set(content_service.searchable_types)
+    try:
+        content_service.content = [unknown_theme]
+        content_service._rebuild_lookup_dicts()
+        content_service.searchable_types = {item.content_type for item in content_service.content}
+
+        mocker.patch(
+            "app.services.data.content_service.content_repository.get_theme_pages_content_batch",
+            return_value=None,
+        )
+        update_mock = mocker.patch(
+            "app.services.data.content_service.content_repository.update_dead_end_theme_page_flags",
+            return_value=1,
+        )
+
+        flags = content_service.refresh_dead_end_theme_page_flags(persist=True)
+
+        update_mock.assert_called_once_with({"theme-unknown": False})
+        assert flags == {"theme-unknown": False}
+        assert content_service.content_by_id["theme-unknown"].is_dead_end_theme_page is False
+    finally:
+        content_service.content = orig_content
+        content_service.content_by_id = orig_by_id
+        content_service.content_by_path = orig_by_path
+        content_service.searchable_types = orig_types

--- a/tests/unit/services/data/test_content_service.py
+++ b/tests/unit/services/data/test_content_service.py
@@ -1,3 +1,6 @@
+from app.entities.content import ContentItem, ContentLink
+
+
 def test_parse_ehelsestandard_fields_reads_attachments_json():
     from app.services.data.content_service import content_service
 
@@ -76,3 +79,85 @@ def test_load_from_api_reloads_from_database_cache_after_refresh(mocker):
     search_mock.assert_called_once_with(query_text="test", get_full_infobits=True)
     cache_mock.assert_called_once()
     load_mock.assert_called_once()
+
+
+def test_refresh_dead_end_theme_page_flags_marks_only_true_dead_ends(mocker):
+    from app.services.data.content_service import content_service
+
+    parent = ContentItem(
+        id="theme-parent",
+        title="Parent theme",
+        body="",
+        content_type="temaside",
+        path="/tema/parent",
+        links=[ContentLink(rel="barn", type="temaside", id="theme-active-child", tittel="Active child")],
+    )
+    active_child = ContentItem(
+        id="theme-active-child",
+        title="Active child",
+        body="",
+        content_type="temaside",
+        path="/tema/active-child",
+        links=[ContentLink(rel="barn", type="rapport", id="report-1", tittel="Report")],
+    )
+    dead_end_child = ContentItem(
+        id="theme-dead-end-child",
+        title="Dead-end child",
+        body="",
+        content_type="temaside",
+        path="/tema/dead-end-child",
+    )
+    report = ContentItem(
+        id="report-1",
+        title="Report",
+        body="Report body",
+        content_type="rapport",
+        path="/rapport/report-1",
+        has_text_content=True,
+    )
+
+    orig_content = content_service.content[:]
+    orig_by_id = dict(content_service.content_by_id)
+    orig_by_path = dict(content_service.content_by_path)
+    orig_types = set(content_service.searchable_types)
+    try:
+        content_service.content = [parent, active_child, dead_end_child, report]
+        content_service._rebuild_lookup_dicts()
+        content_service.searchable_types = {
+            item.content_type for item in content_service.content
+        }
+
+        batch_mock = mocker.patch(
+            "app.services.data.content_service.content_repository.get_theme_pages_content_batch",
+            return_value={},
+        )
+        update_mock = mocker.patch(
+            "app.services.data.content_service.content_repository.update_dead_end_theme_page_flags",
+            return_value=3,
+        )
+
+        flags = content_service.refresh_dead_end_theme_page_flags(persist=True)
+
+        batch_mock.assert_called_once_with(
+            ["theme-parent", "theme-active-child", "theme-dead-end-child"]
+        )
+        update_mock.assert_called_once_with(
+            {
+                "theme-parent": False,
+                "theme-active-child": False,
+                "theme-dead-end-child": True,
+            }
+        )
+        assert flags == {
+            "theme-parent": False,
+            "theme-active-child": False,
+            "theme-dead-end-child": True,
+        }
+        assert content_service.content_by_id["theme-parent"].is_dead_end_theme_page is False
+        assert content_service.content_by_id["theme-active-child"].is_dead_end_theme_page is False
+        assert content_service.content_by_id["theme-dead-end-child"].is_dead_end_theme_page is True
+    finally:
+        content_service.content = orig_content
+        content_service.content_by_id = orig_by_id
+        content_service.content_by_path = orig_by_path
+        content_service.searchable_types = orig_types


### PR DESCRIPTION
… tags in API responses, and update tests for frontend navigation behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results, theme pages, and suggestions now include a `tags` field to indicate content status.
  * Added detection for "dead-end" theme pages, marked with a `no_content` tag when they lack navigable content.

* **Bug Fixes**
  * Improved filtering of empty theme pages based on actual navigability rather than text content presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->